### PR TITLE
Added calibre and node installation

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,7 +38,13 @@
   },
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-python"
+    },
+    {
+      "url": "https://github.com/pawitp/heroku-buildpack-calibre"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -44,7 +44,7 @@
       "url": "https://github.com/heroku/heroku-buildpack-python"
     },
     {
-      "url": "https://github.com/pawitp/heroku-buildpack-calibre"
+      "url": "https://github.com/nntin/heroku-buildpack-calibre"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lightnovel-crawler",
+  "description": "Downloads lightnovels from various online sources and generates ebooks in many formats.",
+  "version": "2.16.2",
+  "engines": {
+    "node": "12.x"
+  }
+}


### PR DESCRIPTION
Calibre and node were not installed leading to limited functionality of the bot.

Added official heroku buildpack for node.js.  
Added an unofficial heroku buildpack for calibre: https://github.com/nntin/heroku-buildpack-calibre