### PR TITLE
fix creativenovels spider chapter listing

### DIFF
--- a/src/spiders/creativenovels.py
+++ b/src/spiders/creativenovels.py
@@ -52,7 +52,8 @@ class CreativeNovelsCrawler(Crawler):
             chapter_list_url,
             data=dict(
                 action='crn_chapter_list',
-                view_id=self.novel_id
+                view_id=self.novel_id,
+                s='5b0f05c825'
             )
         )
         self.parse_chapter_list(response.content.decode('utf-8'))


### PR DESCRIPTION
There's a magic hex value added as another POST parameter that's now required.  It seems to be the same across sessions.