### PR TITLE
creativenovels.com scraper: clean up nag spans and style tagbarf

### DIFF
--- a/src/spiders/creativenovels.py
+++ b/src/spiders/creativenovels.py
@@ -113,10 +113,11 @@ class CreativeNovelsCrawler(Crawler):
         for tag in body.select('.announcements_crn'):
             tag.decompose()
         # end for
-        for b in body.select('b'):
-            if b.get('style') == 'color:transparent;':
-                b.decompose()
-            # end if
+        for span in body.find_all('span'):
+            span.decompose()
+        # end for
+        for span in body.find_all('style'):
+            span.decompose()
         # end for
 
         self.clean_contents(body)


### PR DESCRIPTION
Due to a recent change in the site, nagtext was implemented as transparent `<span>` tags, and there were `<style>` tags at the end of each chapter for buttons that didn't render in scraped output anyways.  This change removes all tags of these types and preserves the desired chapter text.