### PR TITLE
Royal Road: Use name <span> instead of author <h4>

### DIFF
--- a/src/sources/royalroad.py
+++ b/src/sources/royalroad.py
@@ -55,7 +55,8 @@ class RoyalRoadCrawler(Crawler):
         logger.info('Novel cover: %s', self.novel_cover)
 
         self.novel_author = soup.find(
-            "h4", {"property": "author"}).text.strip()
+            "span", {"property": "name"}).text.strip()
+        print(self.novel_author)
         logger.info('Novel author: %s', self.novel_author)
 
         chapters = soup.find('tbody').findAll('a', href=True)

--- a/src/sources/royalroad.py
+++ b/src/sources/royalroad.py
@@ -56,7 +56,6 @@ class RoyalRoadCrawler(Crawler):
 
         self.novel_author = soup.find(
             "span", {"property": "name"}).text.strip()
-        print(self.novel_author)
         logger.info('Novel author: %s', self.novel_author)
 
         chapters = soup.find('tbody').findAll('a', href=True)


### PR DESCRIPTION
This changes Royal Road downloads to use the "name" `<span>` instead of the "author" `<h4>` since the author was including "by" and two newlines which was causing the author name to glitch out in some apps. If having "by" is desired I can have it add that back in, but the newlines should be removed.

I saw you rebased my last PR to dev so sorry if I'm doing the wrong branch on master 😅, dev hasn't updated though so I just did this one on master too.

---

### Before:
Apple Books cuts off the name:
![スクリーンショット 2020-06-04 23 26 08](https://user-images.githubusercontent.com/41608708/83837275-9ceb8f80-a6bb-11ea-838f-61cdb61ef2ab.png)
calibre shows it correctly, but with `by`:
![スクリーンショット 2020-06-04 23 26 31](https://user-images.githubusercontent.com/41608708/83837283-a248da00-a6bb-11ea-9a8f-3a7923230cc0.png)
How the raw value looks:
![スクリーンショット 2020-06-04 23 28 33](https://user-images.githubusercontent.com/41608708/83837289-a4ab3400-a6bb-11ea-83ce-661dd5ff2b88.png)

### After:
Working correctly in Apple Books:
![スクリーンショット 2020-06-04 23 27 37](https://user-images.githubusercontent.com/41608708/83837294-a7a62480-a6bb-11ea-91ca-97be1c55cd9d.png)
Same in calibre:
![スクリーンショット 2020-06-04 23 29 10](https://user-images.githubusercontent.com/41608708/83837296-a8d75180-a6bb-11ea-9c22-cc84ab3d4a73.png)
No extraneous newlines:
![スクリーンショット 2020-06-04 23 28 52](https://user-images.githubusercontent.com/41608708/83837299-a96fe800-a6bb-11ea-82c6-8da16a70632e.png)

