### PR TITLE
rename the 'src' folder and modify setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ else:
 
     config.read_configuration('setup.cfg')
     setup(
+        name='lncrawl',
         version=parse_version(os.path.join('src', 'VERSION')),
         install_requires=parse_requirements('requirements.txt'),
     )

--- a/src/sources/babelnovel.py
+++ b/src/sources/babelnovel.py
@@ -75,7 +75,7 @@ class BabelNovelCrawler(Crawler):
         self.novel_cover = data['data']['cover']
         logger.info('Novel cover: %s', self.novel_cover)
 
-        chapter_count = int(data['data']['chapterCount'])
+        chapter_count = int(data['data']['releasedChapterCount'])
         self.get_list_of_chapters(chapter_count)
     # end def
 


### PR DESCRIPTION
This renames `src` to `lncrawl` since that's what the package name is. Also added some PyPI metadata\
This fixes issue with pip and other package managers defining the package as `src` in python path when used as a module.

i.e.
```diff
- import src as lncrawl
+ import lncrawl
```