### PR TITLE
Allows Non-Specified Args to be used

### DIFF
--- a/lncrawl/core/arguments.py
+++ b/lncrawl/core/arguments.py
@@ -47,7 +47,7 @@ class Args:
 
     def get_args(self):
         if self.arguments is None:
-            self.arguments = self.build().parse_args()
+            self.arguments, _ = self.build().parse_known_args()
         # end if
         return self.arguments
     # end def


### PR DESCRIPTION
So this change allows the core to be run even with non-specified args in the arg list. This is needed if other programs are using the crawler as a library, so it does not stall. 