### PR TITLE
Fix Discord bot on Heroku

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-libc6 libglapi-mesa libxdamage1 libxfixes3 libxcb-glx0 libxcb-dri2-0 libxcb-dri3-0 libxcb-present0 libxcb-sync1 libxshmfence1 libxxf86vm1
+libc6 libglapi-mesa libxdamage1 libxfixes3 libxcb-glx0 libxcb-dri2-0 libxcb-dri3-0 libxcb-present0 libxcb-sync1 libxshmfence1 libxxf86vm1 libxrender1 libxtst6 libxi6

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+libc6 libglapi-mesa libxdamage1 libxfixes3 libxcb-glx0 libxcb-dri2-0 libxcb-dri3-0 libxcb-present0 libxcb-sync1 libxshmfence1 libxxf86vm1

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-bot: python .
+bot: python . --shard-id 0 --shard-count 1

--- a/app.json
+++ b/app.json
@@ -44,6 +44,9 @@
       "url": "https://github.com/heroku/heroku-buildpack-python"
     },
     {
+      "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
       "url": "https://github.com/nntin/heroku-buildpack-calibre"
     }
   ]


### PR DESCRIPTION
Fixing the Discord client on Heroku, see https://github.com/dipu-bd/lightnovel-crawler/issues/664

added `--shard-id 0 --shard-count 1` to CLI
added Aptfile with libraries necessary for Calibre. (Converting to web had errors about missing files.)