### PR TITLE
Allow --format argument to be case-insensitive

### DIFF
--- a/lncrawl/core/arguments.py
+++ b/lncrawl/core/arguments.py
@@ -76,7 +76,7 @@ _builder = Args(group=[
          help='User name/email address and password for login.'),
 
     Args('--format', dest='output_formats', nargs='+', metavar='E',
-         choices=available_formats, default=list(),
+         choices=available_formats, default=list(), type=str.lower,
          help='Define which formats to output. Default: all.'),
     Args('--add-source-url', action='store_true',
          help='Add source url at the end of each chapter.'),


### PR DESCRIPTION
Allow --format argument to be case-insensitive by converting it to lower case.

Currently passing --format MOBI or similar would cause an error: 

lncrawl: error: argument --format: invalid choice: 'MOBI' (choose from 'epub', 'text', 'web', 'docx', 'mobi', 'pdf', 'rtf', 'txt', 'azw3', 'fb2', 'lit', 'lrf', 'oeb', 'pdb', 'rb', 'snb', 'tcr')

However, as all values for --format are lowercase we can just convert user input to lower case. This commit makes it possible to pass MOBI/Mobi/MoBi in any desired case as a --format argument value. Value is converted to lowercase before validation. Downstream code receives lowercase value.

Documentation for type argument: https://docs.python.org/3/library/argparse.html#type
Similar question on SO: https://stackoverflow.com/questions/27616778/case-insensitive-argparse-choices