### PR TITLE
Make beautifulsoup escape <> as &lt;&gt; for readnovelfull.com

### DIFF
--- a/lncrawl/sources/readnovelfull.py
+++ b/lncrawl/sources/readnovelfull.py
@@ -90,18 +90,12 @@ class ReadNovelFullCrawler(Crawler):
         '''Download body of a single chapter and return as clean html format.'''
         logger.info('Downloading %s', chapter['url'])
         soup = self.get_soup(chapter['url'])
-        root = soup.find('div', id='chr-content')
 
-        if not root:
+        content = soup.select('#chr-content p')
+        if not content:
             return ''
         # end if
 
-        body = [
-            t
-            for t in root.find_all(text=True)
-            if t.parent.name not in self.bad_tags and t.strip()
-        ]
-
-        return '<p>' + '</p><p>'.join(body) + '</p>'
+        return "".join(map(str, content))
     # end def
 # end class


### PR DESCRIPTION
The previous solution didn't escape <>. This resulted in ebooklib doing stupid things like this
```html
<p>‘Ding! Gold Venomous Python King has used <strangle>!’</strangle></p>
```

The current solution results in
```html
<p>\u2018Ding! Gold Venomous Python King has used &lt;Strangle&gt;!\u2019</p>
```

fixes #803