### PR TITLE
Novelfull fix

### DIFF
--- a/lncrawl/sources/bestlightnovel.py
+++ b/lncrawl/sources/bestlightnovel.py
@@ -85,6 +85,8 @@ class BestLightNovel(Crawler):
         ]
 
         contents = soup.select_one('#vung_doc')
+        for bad in contents.select('br'):
+            bad.decompose()
         body = self.extract_contents(contents)
         return '<p>' + '</p><p>'.join(body) + '</p>'
     # end def

--- a/lncrawl/sources/novelfull.py
+++ b/lncrawl/sources/novelfull.py
@@ -124,9 +124,15 @@ class NovelFullCrawler(Crawler):
         logger.info('Downloading %s', chapter['url'])
         soup = self.get_soup(chapter['url'])
 
-        content = soup.select('div#chapter-content p')
-        content = '\n'.join(str(p) for p in content)
+        contents = soup.select_one('div#chapter-content')
 
-        return content
+        for bad in contents.select('div, ins, iframe, .ads-middle, .code-block, script, .adsbygoogle'):
+            bad.decompose()
+
+        for end in contents.findAll('div', {"align": 'left'}):
+            end.decompose()
+
+        body = self.extract_contents(contents)
+        return '<p>' + '</p><p>'.join(body) + '</p>'
     # end def
 # end class


### PR DESCRIPTION
I noticed that random chapters was missing the first paragraph on each chapter. This was caused by novelfull putting first paragraph with tags (in between tags) like this.

```
<p></p>
This is first paragraph text.
<p></p>
<p>This is second paragraph.</p>
```

The code I've changed allows it to fetch everything even if it's not in a `<p>` tag. If you want to see what I mean here is a url to a book and the chapter old code has problems fetching.

https://novelfull.com/the-mech-touch/chapter-438-barras.html

**Update:**
Also added code to bestlightnovel.py to remove `<p><br></p>` from chapters, it was causing double line breaks  in between paragraphs on all chapters.