### PR TITLE
Fix lightnovelstranslations href error

### DIFF
--- a/lncrawl/sources/lightnovetrans.py
+++ b/lncrawl/sources/lightnovetrans.py
@@ -28,6 +28,8 @@ class LNTCrawler(Crawler):
                 'title': vol,
             })
             for a in div.select('.su-spoiler-content p a'):
+                if not a.has_attr('href'):
+                    continue
                 self.chapters.append({
                     'id': len(self.chapters) + 1,
                     'volume': vol_id,


### PR DESCRIPTION
Fix to skip entry with empty <a> tag in the index of the novel. I extracted the part of the page that was causing problems for the parsing function below. The <a> tag without href attribute was causing a Key Error.

```html
<!-- Extract from https://lightnovelstranslations.com/i-woke-up-piloting-the-strongest-starship-so-i-became-a-space-mercenary/-->
<a href="https://lightnovelstranslations.com/i-woke-up-piloting-the-strongest-starship-so-i-became-a-space-mercenary/095-contact/">Chapter 95</a>
<a><br></a>
<a href="https://lightnovelstranslations.com/i-woke-up-piloting-the-strongest-starship-so-i-became-a-space-mercenary/096-formal-meeting-with-the-earl/">Chapter 96</a>
```