### PR TITLE
Gracefully handle novel info failures.

### DIFF
--- a/lncrawl/bots/console/start.py
+++ b/lncrawl/bots/console/start.py
@@ -68,7 +68,16 @@ def start(self):
         self.app.login_data = self.get_login_info()
     # end if
 
-    self.app.get_novel_info()
+    success = self.app.get_novel_info()
+    while not success:
+        # Get the user to try again
+        #TODO: refactor so login is supported
+        novel_url = self.choose_a_novel()
+        self.log.info('Selected novel: %s' % novel_url)
+        self.app.init_crawler(novel_url)
+
+        success = self.app.get_novel_info()
+    # end while
 
     self.app.output_path = self.get_output_path()
     self.app.chapters = self.process_chapter_range()

--- a/lncrawl/core/app.py
+++ b/lncrawl/core/app.py
@@ -136,7 +136,13 @@ class App:
 
         print('Retrieving novel info...')
         print(self.crawler.novel_url)
-        self.crawler.read_novel_info()
+        try:
+            self.crawler.read_novel_info()
+        except Exception as err:
+            print('Error reading novel info: %s' % err)
+            # Go back to the source list to allow the user to try again
+
+            return False
         print('NOVEL: %s' % self.crawler.novel_title)
         print('%d volumes and %d chapters found' %
               (len(self.crawler.volumes), len(self.crawler.chapters)))
@@ -155,6 +161,9 @@ class App:
 
         source_name = slugify(urlparse(self.crawler.home_url).netloc)
         self.output_path = os.path.join(C.DEFAULT_OUTPUT_PATH, source_name, self.good_file_name)
+
+        # Success
+        return True
     # end def
 
     # ----------------------------------------------------------------------- #


### PR DESCRIPTION
Often, sources are broken and fail when fetching novel info.

Instead of crashing back to command line, allow the user to choose a different source without repeating the title entry / search / other steps.

Note: This is a quick proof of concept and needs someone more familiar with the code base to clean it up and support login.