### PR TITLE
Fix issue in source RoyalRoad.

### DIFF
--- a/sources/en/r/royalroad.py
+++ b/sources/en/r/royalroad.py
@@ -39,7 +39,7 @@ class RoyalRoadCrawler(Crawler):
         logger.info('Novel title: %s', self.novel_title)
 
         self.novel_cover = self.absolute_url(
-            soup.find("img", {"class": "img-offset thumbnail inline-block"})['src'])
+            soup.find("img", {"class": "thumbnail inline-block"})['src'])
         logger.info('Novel cover: %s', self.novel_cover)
 
         self.novel_author = soup.find(


### PR DESCRIPTION
A change in the Story image handling on the website, requiring to remove one of the filter.
Tested on stories with both custom images and default images.