### PR TITLE
Fix wattpad login

### DIFF
--- a/sources/multi/wattpad.py
+++ b/sources/multi/wattpad.py
@@ -33,9 +33,9 @@ class WattpadCrawler(Crawler):
         
         data = self.get_json('https://www.wattpad.com/api/v3/internal/current_user?fields=email,username,name')
         logger.debug('current user', data)
-        if email != data['username']:
+        if email.lower() != data['username'].lower():
             raise Exception('Failed to login')
-        print('Logged in as %s[%s]<%s>' % data['name'], data['username'], data['email'])
+        print('Logged in as %s[%s]<%s>' % (data['name'], data['username'], data['email']))
 
     def read_novel_info(self):
 


### PR DESCRIPTION
Copy and paste from my comment on #1407 

---

I know this is a closed issue, but might I suggest some changes:

1. Line `39`, change:
```python
if email != data['username']:
```
to
```python
if email.lower() != data['username'].lower:
```

(The check makes both into lowercase strings so case sensitivity can be ignored.)

The reasoning behind this is that Wattpad usernames for login are case insensitive, so if you're like me and your username on Wattpad is officially `Tycoonlover1359` (note the uppercase `T`) but your login in your password manager is noted as `tycoonlover1359` (note the lowercase `t`), then this check fails despite having successfully logged in.

2. line `40`, change:
```python
print('Logged in as %s[%s]<%s>' % data['name'], data['username'], data['email'])
```
to
```python
print('Logged in as %s[%s]<%s>' % (data['name'], data['username'], data['email']))
```

(The format string is now provided a tuple of arguments.)

In my testing, this line would otherwise raise a `TypeError: not enough arguments for format string` error, which makes sense as the first revision is interpreted and run as 3 arguments to the print command, not a single string formatted with 3 arguments.

---

I have added these changes in a pull request, #1458 