### PR TITLE
fix progress

### DIFF
--- a/lncrawl/core/downloader.py
+++ b/lncrawl/core/downloader.py
@@ -155,8 +155,6 @@ def download_chapter_body(app, chapter):
             except Exception as e:
                 logger.debug('Failed', e)
                 return f"[{chapter['id']}] Failed to get chapter body ({e.__class__.__name__}: {e})"
-            finally:
-                app.progress += 1
             # end try
         # end for
     finally:


### PR DESCRIPTION
I'm not sure about this, but I believe this cause the ```app.progress``` value to be wrong (in bots, not in the console progress bar).
Both ```finally``` block can sometimes be triggered which increment the progress more than once for a chapter, giving for example 300/170 chapters downloaded.
Removing this seems to fix it for the few novels I tried.