### PR TITLE
Fix ```signal only work in main thread``` error in bots

### DIFF
--- a/lncrawl/core/downloader.py
+++ b/lncrawl/core/downloader.py
@@ -39,8 +39,9 @@ def resolve_all_futures(futures_to_check, desc='', unit=''):
             raise LNException('Cancelled by user')
         # end if
     # end def
-
-    signal.signal(signal.SIGINT, cancel_all)
+    
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGINT, cancel_all)
 
     try:
         for future in futures_to_check:

--- a/lncrawl/core/downloader.py
+++ b/lncrawl/core/downloader.py
@@ -9,6 +9,7 @@ import logging
 import os
 from io import BytesIO
 import signal
+import threading
 
 import bs4
 from PIL import Image


### PR DESCRIPTION
```signal.signal(signal.SIGINT, cancel_all)``` does not work outside main thread. Bots use a thread for each session, so it raise ```signals only work in main thread``` error when downloading anything.

This is a temporary fix as I don't know how to easily implement this feature without signal. This just disable the feature outside main thread. So it disable it for bots (telegram, discord) but not for console.
Keyboard interrupt are less likely to happens to bots anyway