### PR TITLE
Correctly Minify CSS and Display Double <br>

### DIFF
--- a/lncrawl/assets/web/style.css
+++ b/lncrawl/assets/web/style.css
@@ -40,8 +40,7 @@ main {
   padding: 0 10px;
 }
 
-p + br,
-br + br {
+p + br{
   display: none;
 }
 

--- a/lncrawl/assets/web/style.py
+++ b/lncrawl/assets/web/style.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 from pathlib import Path
+from css_html_js_minify import css_minify
 
 ROOT = Path(__file__).parent
 
@@ -10,45 +11,6 @@ with open(str(ROOT / 'style.css'), 'r', encoding='utf8') as f:
 
 
 def get_value():
-    return _minify(style)
-# end def
-
-
-def _minify(css):
-    result = ''
-
-    # remove comments - this will break IE<6 comment hacks
-    css = re.sub(r'/\*[\s\S]*?\*/', "", css)
-
-    # url() doesn't need quotes
-    #css = re.sub(r'url\((["\'])([^)]*)\1\)', r'url(\2)', css)
-
-    # spaces may be safely collapsed as generated content will collapse them anyway
-    css = re.sub(r'\s+', ' ', css)
-
-    # shorten collapsable colors: #aabbcc to #abc
-    css = re.sub(
-        r'#([0-9a-f])\1([0-9a-f])\2([0-9a-f])\3(\s|;)', r'#\1\2\3\4', css)
-
-    # fragment values can loose zeros
-    css = re.sub(r':\s*0(\.\d+([cm]m|e[mx]|in|p[ctx]))\s*;', r':\1;', css)
-
-    for rule in re.findall(r'([^{]+){([^}]*)}', css):
-        # we don't need spaces around operators
-        selectors = [re.sub(r'(?<=[\[\(>+=])\s+|\s+(?=[=~^$*|>+\]\)])',
-                            r'', selector.strip()) for selector in rule[0].split(',')]
-        # order is important, but we still want to discard repetitions
-        properties = {}
-        porder = []
-        for prop in re.findall(r'(.*?):(.*?)(;|$)', rule[1]):
-            key = prop[0].strip().lower()
-            if key not in porder:
-                porder.append(key)
-            properties[key] = prop[1].strip()
-            # output rule if it contains any declarations
-            if properties:
-                result += "%s{%s}" % (','.join(selectors), ''.join(
-                    ['%s:%s;' % (key, properties[key]) for key in porder])[:-1])
-
-    return result
+    t = css_minify(style)
+    return css_minify(style)
 # end def

--- a/lncrawl/assets/web/style.py
+++ b/lncrawl/assets/web/style.py
@@ -11,6 +11,5 @@ with open(str(ROOT / 'style.css'), 'r', encoding='utf8') as f:
 
 
 def get_value():
-    t = css_minify(style)
     return css_minify(style)
 # end def

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ questionary>=1.6.0
 prompt-toolkit~=3.0
 html5lib~=1.1
 base58~=2.1.1
-css_html_js_minify>=2.5.5
+css-html-js-minify>=2.5.5
 
 # dev requirements
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ questionary>=1.6.0
 prompt-toolkit~=3.0
 html5lib~=1.1
 base58~=2.1.1
+css_html_js_minify>=2.5.5
 
 # dev requirements
 wheel


### PR DESCRIPTION
The previous approach to minifying CSS lead to duplicate entries in the CSS and missing closing brackets:
![image](https://user-images.githubusercontent.com/34796386/191517700-0d41cfdc-2661-4b2d-83ec-ce4526a68a9c.png)
![image](https://user-images.githubusercontent.com/34796386/191517748-c4f4a385-febd-4c52-b3b7-3cede8e23ffd.png)

Setting `<br><br>` to _display none_ lead to some novels not rendering correctly. In my opinion completely removing `<br><br>` is not the way to go. If two `<br>` are too much, we can just replace them by one in code.