### PR TITLE
Correctly remove multiple <br> and keep more styles

### DIFF
--- a/lncrawl/assets/epub/__init__.py
+++ b/lncrawl/assets/epub/__init__.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+
+def get_css_style():
+    with open(str(ROOT / "style.css"), "r", encoding="utf8") as f:
+        style = f.read()
+    return style

--- a/lncrawl/assets/epub/style.css
+++ b/lncrawl/assets/epub/style.css
@@ -1,0 +1,26 @@
+img {
+    width: 100vw;
+    object-fit: scale-down;
+    object-position: center center;
+}
+
+p+br {
+    display: none;
+}
+
+#intro {
+    max-height: 95vh;
+    min-height: 450px;
+    display: flex;
+    text-align: center;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center
+}
+
+#cover {
+    max-height: 50vh;
+    min-height: 30vh;
+    object-fit: contain;
+    object-position: center center
+}

--- a/lncrawl/assets/web/style.css
+++ b/lncrawl/assets/web/style.css
@@ -40,8 +40,7 @@ main {
   padding: 0 10px;
 }
 
-p + br,
-br + br {
+p + br{
   display: none;
 }
 

--- a/lncrawl/utils/cleaner.py
+++ b/lncrawl/utils/cleaner.py
@@ -102,8 +102,8 @@ class TextCleaner:
             ">": "&gt;",
         }
         self.allowed_inline_styles = [
-            'font-style',
-            'font-weight'
+            "font-style",
+            "font-weight"
         ]
 
     def extract_contents(self, tag) -> str:
@@ -129,21 +129,21 @@ class TextCleaner:
         for tag in div.find_all(True):
             if isinstance(tag, Comment):
                 tag.extract()   # Remove comments
-            elif tag.name == 'br':
+            elif tag.name == "br":
                 if tag.nextSibling is not None:
-                    while tag.next_sibling.text.strip() == '' or tag.next_sibling.name == 'br':
+                    while tag.next_sibling.text.strip() == "" or tag.next_sibling.name == "br":
                         tag.next_sibling.extract()
                         if tag.nextSibling is None:
                             break
 
             elif tag.name in self.bad_tags:
                 tag.extract()   # Remove bad tags
-            elif hasattr(tag, 'attrs'):
+            elif hasattr(tag, "attrs"):
                 cleaned_attrs = {}
                 for k, v in tag.attrs.items():
-                    if k == 'src':
+                    if k == "src":
                         cleaned_attrs[k] = v
-                    elif k == 'style':
+                    elif k == "style":
                         cleaned_styles = []
                         styles = v.split(";")
                         for style in styles:

--- a/lncrawl/utils/cleaner.py
+++ b/lncrawl/utils/cleaner.py
@@ -103,7 +103,7 @@ class TextCleaner:
         }
         self.allowed_inline_styles = [
             'font-style',
-            'font-weght'
+            'font-weight'
         ]
 
     def extract_contents(self, tag) -> str:

--- a/lncrawl/utils/cleaner.py
+++ b/lncrawl/utils/cleaner.py
@@ -101,6 +101,10 @@ class TextCleaner:
             "<": "&lt;",
             ">": "&gt;",
         }
+        self.allowed_inline_styles = [
+            'font-style',
+            'font-weght'
+        ]
 
     def extract_contents(self, tag) -> str:
         self.clean_contents(tag)
@@ -124,16 +128,31 @@ class TextCleaner:
 
         for tag in div.find_all(True):
             if isinstance(tag, Comment):
-                tag.extract()  # Remove comments
-            elif tag.name == "br":
-                next_tag = getattr(tag, "next_sibling")
-                if next_tag and getattr(next_tag, "name") == "br":
-                    tag.extract()
+                tag.extract()   # Remove comments
+            elif tag.name == 'br':
+                if tag.nextSibling is not None:
+                    while tag.next_sibling.text.strip() == '' or tag.next_sibling.name == 'br':
+                        tag.next_sibling.extract()
+                        if tag.nextSibling is None:
+                            break
 
             elif tag.name in self.bad_tags:
-                tag.extract()  # Remove bad tags
-            elif hasattr(tag, "attrs"):
-                tag.attrs = {k: v for k, v in tag.attrs.items() if k == "src"}
+                tag.extract()   # Remove bad tags
+            elif hasattr(tag, 'attrs'):
+                cleaned_attrs = {}
+                for k, v in tag.attrs.items():
+                    if k == 'src':
+                        cleaned_attrs[k] = v
+                    elif k == 'style':
+                        cleaned_styles = []
+                        styles = v.split(";")
+                        for style in styles:
+                            if style.split(":")[0].strip().lower() in self.allowed_inline_styles:
+                                cleaned_styles.append(style.strip())
+                        if len(cleaned_styles) > 0:
+                            cleaned_attrs[k] = ";".join(cleaned_styles)
+
+                tag.attrs = cleaned_attrs
 
         div.attrs = {}
         return div

--- a/lncrawl/utils/cleaner.py
+++ b/lncrawl/utils/cleaner.py
@@ -101,10 +101,6 @@ class TextCleaner:
             "<": "&lt;",
             ">": "&gt;",
         }
-        self.allowed_inline_styles = [
-            "font-style",
-            "font-weight"
-        ]
 
     def extract_contents(self, tag) -> str:
         self.clean_contents(tag)
@@ -130,29 +126,14 @@ class TextCleaner:
             if isinstance(tag, Comment):
                 tag.extract()   # Remove comments
             elif tag.name == "br":
-                if tag.nextSibling is not None:
-                    while tag.next_sibling.text.strip() == "" or tag.next_sibling.name == "br":
-                        tag.next_sibling.extract()
-                        if tag.nextSibling is None:
-                            break
-
+                next_tag = getattr(tag, "next_sibling", "")
+                while next_tag and getattr(next_tag, "name", '') == "br"):
+                    tag.extract()
+                    next_tag = getattr(tag, "next_sibling", "")
             elif tag.name in self.bad_tags:
-                tag.extract()   # Remove bad tags
+                tag.extract()  # Remove bad tags
             elif hasattr(tag, "attrs"):
-                cleaned_attrs = {}
-                for k, v in tag.attrs.items():
-                    if k == "src":
-                        cleaned_attrs[k] = v
-                    elif k == "style":
-                        cleaned_styles = []
-                        styles = v.split(";")
-                        for style in styles:
-                            if style.split(":")[0].strip().lower() in self.allowed_inline_styles:
-                                cleaned_styles.append(style.strip())
-                        if len(cleaned_styles) > 0:
-                            cleaned_attrs[k] = ";".join(cleaned_styles)
-
-                tag.attrs = cleaned_attrs
+                tag.attrs = {k: v for k, v in tag.attrs.items() if k == "src"}
 
         div.attrs = {}
         return div


### PR DESCRIPTION
The code for removing multiple `<br>` did not work in my case. The cleaner will now also remove  multiple `<br>` if they are separated by white space characters.

Some novels inline styles like bold or italic for effect. Those styles will now also be kept.

Hiding `<br><br>` through CSS leads to issues, because the included CSS will also affect  `<br>text<br>` since the plain text is ignored when applying the selector. I have therefore removed it again. Also, this CSS is not needed, since now there should not be multiple `<br>` after the cleaning step.
![image](https://user-images.githubusercontent.com/34796386/192080266-df012310-e3ce-483e-bd9e-42691a1daf11.png)
 