### PR TITLE
Fix https://puretl.com/

### DIFF
--- a/sources/en/p/puretl.py
+++ b/sources/en/p/puretl.py
@@ -48,7 +48,12 @@ class PeryInfo(Crawler):
 
         logger.info("Novel author: %s", self.novel_author)
 
-        content = soup.select_one("#sections section:nth-of-type(2)")
+        chapter_strong = soup.find("strong", string=re.compile("Chapter List"))
+        if not isinstance(chapter_strong, Tag):
+            raise LNException("No chapters found")
+
+        content = chapter_strong.find_parent("section")
+
         for a in content.select(f"a[href*='{slug}/']"):
             self.chapters.append(
                 {


### PR DESCRIPTION
https://github.com/dipu-bd/lightnovel-crawler/issues/1635

@dipu-bd 
Look what an idea I have. I'm looking first for a unique tag for this site (for ex.: strong with text or tag with **_unique class for content block_**), which is located in the block I need (the section tag). After that, I'm looking for the parent of this tag (section). And it works!

``` py
chapter_strong = soup.find("strong", string=re.compile("Chapter List"))
content = chapter_strong.find_parent("section")
```

![image](https://user-images.githubusercontent.com/11484976/192209615-0d8e6310-c52b-4ddf-a72f-215c73780f5d.png)
