### PR TITLE
Fix table text-align scribblehub

### DIFF
--- a/sources/en/s/scribblehub.py
+++ b/sources/en/s/scribblehub.py
@@ -144,7 +144,6 @@ class ScribbleHubCrawler(Crawler):
         body = str(contents)
         body += """<style type="text/css">
         table {
-            text-align: center;
             margin: 0 auto;
             border: 2px solid;
             border-collapse: collapse;


### PR DESCRIPTION
text-align is not universal for table.