### PR TITLE
novelnext

### DIFF
--- a/sources/en/n/novelnext.py
+++ b/sources/en/n/novelnext.py
@@ -12,7 +12,10 @@ class NovelNextCrawler(NovelFullTemplate):
     def initialize(self) -> None:
         self.cleaner.bad_tag_text_pairs.update(
             {
-                "h4": r"Chapter \d+",
+                "h4": [
+                    r"Chapter \d+",
+                    r"^\s*(Translator|Editor):.*$",
+                    ],
                 "p": [
                     r"^\s*(Translator|Editor):.*$",
                     r"Bookmark this website \( ",
@@ -21,3 +24,4 @@ class NovelNextCrawler(NovelFullTemplate):
                 "strong": r"NovelNext\.com",
             }
         )
+        


### PR DESCRIPTION
Some translator names were left in because they had an H4 tag. Update to remove that. Tested on a few novels, all are working fine.