### PR TITLE
Fix beautymanga cover 

### DIFF
--- a/sources/en/b/beautymanga.py
+++ b/sources/en/b/beautymanga.py
@@ -38,7 +38,7 @@ class BeautymangaCrawler(Crawler):
 
         possible_image = soup.select_one(".summary_image img")
         if possible_image:
-            self.novel_cover = self.absolute_url(possible_image["src"])
+            self.novel_cover = self.absolute_url(possible_image["data-src"])
         logger.info("Novel cover: %s", self.novel_cover)
 
         self.novel_author = ", ".join(


### PR DESCRIPTION
when loading the page the cover `src` is a blank placeholder that then get replaced with the cover `data-src`. The crawler was downloading the blank placeholder instead of the actual cover.