### PR TITLE
Fix novelfullme cover

### DIFF
--- a/sources/en/n/novelfullme.py
+++ b/sources/en/n/novelfullme.py
@@ -40,7 +40,7 @@ class NovelFullMeCrawler(Crawler):
 
         img_tag = soup.select_one(".img-cover img")
         if isinstance(img_tag, Tag):
-            self.novel_cover = self.absolute_url(img_tag["src"])
+            self.novel_cover = self.absolute_url(img_tag["data-src"])
 
         logger.info("Novel cover: %s", self.novel_cover)
 


### PR DESCRIPTION
when loading the page the cover `src` is a blank placeholder that then get replaced with the cover `data-src`. The crawler was downloading the blank placeholder instead of the actual cover.