### PR TITLE
Fix noveltranslate cover

### DIFF
--- a/sources/en/n/noveltranslate.py
+++ b/sources/en/n/noveltranslate.py
@@ -42,7 +42,7 @@ class NovelTranslateCrawler(Crawler):
         logger.info("Novel title: %s", self.novel_title)
 
         self.novel_cover = self.absolute_url(
-            soup.select_one(".summary_image a img")["src"]
+            soup.select_one(".summary_image a img")["data-lazy-src"]
         )
         logger.info("Novel cover: %s", self.novel_cover)
 

--- a/sources/en/n/noveltranslate.py
+++ b/sources/en/n/noveltranslate.py
@@ -40,7 +40,7 @@ class NovelTranslateCrawler(Crawler):
             span.extract()
         self.novel_title = possible_title.text.strip()
         logger.info("Novel title: %s", self.novel_title)
-        
+
         pimg = soup.select_one(".summary_image a img")
         if pimg:
             self.novel_cover = self.absolute_url(pimg["data-lazy-src"])

--- a/sources/en/n/noveltranslate.py
+++ b/sources/en/n/noveltranslate.py
@@ -40,10 +40,10 @@ class NovelTranslateCrawler(Crawler):
             span.extract()
         self.novel_title = possible_title.text.strip()
         logger.info("Novel title: %s", self.novel_title)
-
-        self.novel_cover = self.absolute_url(
-            soup.select_one(".summary_image a img")["data-lazy-src"]
-        )
+        
+        pimg = soup.select_one(".summary_image a img")
+        if pimg:
+            self.novel_cover = self.absolute_url(pimg["data-lazy-src"])
         logger.info("Novel cover: %s", self.novel_cover)
 
         self.novel_author = " ".join(


### PR DESCRIPTION
when loading the page the cover `src` is a blank placeholder that then get replaced with the cover `data-lazy-src`. The crawler was downloading the placeholder instead of the actual cover.