### PR TITLE
Fix `mangaread` cover and author

### DIFF
--- a/sources/en/m/mangaread.py
+++ b/sources/en/m/mangaread.py
@@ -47,7 +47,7 @@ class MangaReadCrawler(Crawler):
         img_src = soup.select_one(".summary_image a img")
 
         if img_src:
-            self.novel_cover = self.absolute_url(img_src["src"])
+            self.novel_cover = self.absolute_url(img_src["data-src"])
 
         logger.info("Novel cover: %s", self.novel_cover)
 

--- a/sources/en/m/mangaread.py
+++ b/sources/en/m/mangaread.py
@@ -54,7 +54,7 @@ class MangaReadCrawler(Crawler):
         self.novel_author = " ".join(
             [
                 a.text.strip()
-                for a in soup.select('.author-content a[href*="manga-author"]')
+                for a in soup.select('.author-content a[href*="m-author"]')
             ]
         )
         logger.info("%s", self.novel_author)


### PR DESCRIPTION
when loading the page the cover `src` is a blank placeholder that then get replaced with the cover `data-src`. The crawler was downloading the placeholder instead of the actual cover.