### PR TITLE
Fix cover

### DIFF
--- a/sources/en/1/1stkissnovel.py
+++ b/sources/en/1/1stkissnovel.py
@@ -50,7 +50,7 @@ class OneKissNovelCrawler(Crawler):
         img_src = soup.select_one(".summary_image a img")
 
         if img_src:
-            self.novel_cover = self.absolute_url(img_src["src"])
+            self.novel_cover = self.absolute_url(img_src["data-src"])
 
         logger.info("Novel cover: %s", self.novel_cover)
 


### PR DESCRIPTION
`src` is a placeholder that will get replaced by the actual cover url. The crawler was downloading the placehold instead of the cover. We can prevent this by taking `data-src` instead.

To easily avoid this kind of bugs when making sources we can use the network tab to get the initial responses.