### PR TITLE
Fix 'royalroad' source novel title and author

### DIFF
--- a/sources/en/r/royalroad.py
+++ b/sources/en/r/royalroad.py
@@ -33,7 +33,7 @@ class RoyalRoadCrawler(Crawler):
         logger.debug("Visiting %s", self.novel_url)
         soup = self.get_soup(self.novel_url)
 
-        self.novel_title = soup.find("h1", {"property": "name"}).text.strip()
+        self.novel_title = soup.find("h1").text.strip()
         logger.info("Novel title: %s", self.novel_title)
 
         self.novel_cover = self.absolute_url(
@@ -41,7 +41,7 @@ class RoyalRoadCrawler(Crawler):
         )
         logger.info("Novel cover: %s", self.novel_cover)
 
-        self.novel_author = soup.find("span", {"property": "name"}).text.strip()
+        self.novel_author = soup.find("a", class_='font-white').text.strip()
         logger.info("Novel author: %s", self.novel_author)
 
         chapter_rows = soup.find("tbody").findAll("tr")


### PR DESCRIPTION
RR Crawler attempted to find tags that no longer existed in the page for novel title and novel author,
The operation resulted the following exception:
`AttributeError: 'NoneType' object has no attribute 'text'`

This PR updates the tag parameters that are used to find the author and title.