### PR TITLE
Rewrite for lightnovels.me

### DIFF
--- a/sources/en/l/lightnovelme.py
+++ b/sources/en/l/lightnovelme.py
@@ -61,6 +61,8 @@ class LightNovelsLive(Crawler):
         )
 
         # Adds proper spacing in the synopsis. (lossy)
+        #
+        # Regex101 link: https://regex101.com/r/lajsXs/3
         for paragraph in re.split(r'[.!?](?=\w+)(?!\S+[.!?()]+(\s|\w))', novel_info['novel_description']):
             if paragraph is None:
                 self.novel_synopsis += "<br/><br/>"

--- a/sources/en/l/lightnovelme.py
+++ b/sources/en/l/lightnovelme.py
@@ -1,30 +1,43 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+import re
+
 from urllib.parse import quote
 
 from bs4.element import Tag
 
 from lncrawl.core.crawler import Crawler
+from lncrawl.models import Volume
+from lncrawl.models import Chapter
 
 logger = logging.getLogger(__name__)
 
-search_url = "https://lightnovels.me/api/search?keyword=%s&index=0&limit=20"
-chapter_list_url = "https://lightnovels.me/api/chapters?id=%d&index=1&limit=15000"
+search_url = "/api/search?keyword=%s&index=0&limit=20"
+chapter_list_url = "/api/chapters?id=%d&index=1&limit=15000"
 
 
-class LightnovelMe(Crawler):
-    base_url = ["https://lightnovels.me/"]
+class LightNovelsLive(Crawler):
+    base_url = [
+        "http://lightnovels.me/",
+        "https://lightnovels.me/",
+        "http://lightnovels.live/",
+        "https://lightnovels.live/"
+    ]
+
+    has_manga = False
+    has_mtl = False
 
     def search_novel(self, query):
-        data = self.get_json(search_url % quote(query))
+        url = self.absolute_url(search_url % quote(query))
+        data = self.get_json(url)
 
         results = []
         for item in data["results"]:
             results.append(
                 {
                     "title": item["novel_name"],
-                    "url": "https://lightnovels.me/novel" + item["novel_slug"],
+                    "url": self.absolute_url("/novel" + item["novel_slug"]),
                     "info": f"Status: {item['status']} | Latest: {item['chapter_name']}",
                 }
             )
@@ -33,42 +46,63 @@ class LightnovelMe(Crawler):
 
     def read_novel_info(self):
         soup = self.get_soup(self.novel_url)
-        script = soup.select_one("script#__NEXT_DATA__")
-        assert isinstance(script, Tag)
+        script = soup.select_one('script#__NEXT_DATA__')
+        assert isinstance(script, Tag), "No available novel info."
+
         data = json.loads(script.text)
 
-        novel_info = data["props"]["pageProps"]["novelInfo"]
-        novel_id = novel_info["novel_id"]
-        self.novel_title = novel_info["novel_name"]
-        self.novel_cover = self.absolute_url(novel_info["novel_image"])
-        self.novel_author = ", ".join(
-            [x["name"] for x in data["props"]["pageProps"]["authors"]]
+        novel_info = data['props']['pageProps']['novelInfo']
+        novel_id = int(novel_info['novel_id'])
+
+        self.novel_title = novel_info['novel_name']
+        self.novel_cover = self.absolute_url(novel_info['novel_image'])
+        self.novel_author = ', '.join(
+            [author['name'] for author in data['props']['pageProps']['authors']]
         )
 
-        data = self.get_json(chapter_list_url % (novel_id))
+        # Add proper spacing in the synopsis. (often lacking)
+        for paragraph in re.split('\\.(?=\\S)', str(novel_info['novel_description'])):
+            if self.novel_synopsis == "":
+                self.novel_synopsis += paragraph
+            else:
+                self.novel_synopsis += "<br/><br/>" + paragraph
 
-        for i, item in enumerate(data["results"]):
-            chap_id = i + 1
-            vol_id = i // 100 + 1
-            if i % 100 == 0:
-                self.volumes.append({"id": vol_id})
+            if paragraph.endswith('!') | paragraph.endswith('?'):
+                pass
+            else:
+                self.novel_synopsis += "."
+
+        self.novel_tags = ', '.join(
+            [genre['name'] for genre in data['props']['pageProps']['genres']]
+        )
+
+        url = self.absolute_url(chapter_list_url % novel_id)
+        data = self.get_json(url)
+
+        for index, item in enumerate(data['results']):
+            chap_id = index + 1
+            vol_id = index // 100 + 1
+            if index % 100 == 0:
+                self.volumes.append(
+                    Volume(id=vol_id)
+                )
             self.chapters.append(
-                {
-                    "id": chap_id,
-                    "volume": vol_id,
-                    "title": item["chapter_name"],
-                    "url": self.absolute_url(item["slug"]),
-                }
+                Chapter(
+                    id=chap_id,
+                    volume=vol_id,
+                    title=item['chapter_name'],
+                    url=self.absolute_url(item["slug"])
+                )
             )
 
     def download_chapter_body(self, chapter):
-        soup = self.get_soup(chapter["url"])
-        script = soup.select_one("script#__NEXT_DATA__")
-        assert isinstance(script, Tag)
-        data = json.loads(script.text)
+        tag = self.get_soup(chapter['url']).select_one(".chapter-content div")
 
-        chapter_info = data["props"]["pageProps"]["cachedChapterInfo"]
-        content = str(chapter_info["content"])
-        content = content.replace("\u003c", "<").replace("\u003e", ">")
-        content = content.replace("<p>" + chapter_info["chapter_name"] + "</p>", "", 1)
-        return content
+        str_chapter = self.cleaner.extract_contents(tag).replace("\\'", "'").strip()
+        if str_chapter == "":
+            print(f"  Warning: no contents in chapter {chapter['id']}, {chapter['title']}.")
+            str_chapter = '<h4>Empty chapter.</h4>' +\
+                          '<p><mark style="color:Green">Hint</mark>: ' +\
+                          'reporting this to your provider <i>might</i> solve the issue.</p>'
+
+        return str_chapter

--- a/sources/en/l/lightnovelme.py
+++ b/sources/en/l/lightnovelme.py
@@ -60,14 +60,15 @@ class LightNovelsLive(Crawler):
             [author['name'] for author in data['props']['pageProps']['authors']]
         )
 
-        # Adds proper spacing in the synopsis. (often lacking)
-        for paragraph in re.split('\\.(?=\\S)', str(novel_info['novel_description'])):
-            if self.novel_synopsis == "":
-                self.novel_synopsis += paragraph
-            else:
-                self.novel_synopsis += "<br/><br/>" + paragraph
+        # Adds proper spacing in the synopsis. (lossy)
+        for paragraph in re.split(r'[.!?](?=\w+)(?!\S+[.!?()]+(\s|\w))', novel_info['novel_description']):
+            if paragraph is None:
+                self.novel_synopsis += "<br/><br/>"
+                continue
 
-            if paragraph.endswith('!') | paragraph.endswith('?'):
+            self.novel_synopsis += paragraph
+
+            if paragraph.endswith('!') | paragraph.endswith('?') | paragraph.endswith('.'):
                 pass
             else:
                 self.novel_synopsis += "."
@@ -98,7 +99,7 @@ class LightNovelsLive(Crawler):
     def download_chapter_body(self, chapter):
         tag = self.get_soup(chapter['url']).select_one(".chapter-content div")
 
-        str_chapter = self.cleaner.extract_contents(tag).replace("\\'", "'").strip()
+        str_chapter = self.cleaner.extract_contents(tag).replace(r"\'", "'").strip()
         if str_chapter == "":
             print(f"  Warning: no contents in chapter {chapter['id']}, {chapter['title']}.")
             str_chapter = '<h4>Empty chapter.</h4>' +\

--- a/sources/en/l/lightnovelme.py
+++ b/sources/en/l/lightnovelme.py
@@ -60,7 +60,7 @@ class LightNovelsLive(Crawler):
             [author['name'] for author in data['props']['pageProps']['authors']]
         )
 
-        # Add proper spacing in the synopsis. (often lacking)
+        # Adds proper spacing in the synopsis. (often lacking)
         for paragraph in re.split('\\.(?=\\S)', str(novel_info['novel_description'])):
             if self.novel_synopsis == "":
                 self.novel_synopsis += paragraph


### PR DESCRIPTION
In addition to adding support for `http` and the alternative domain `lightnovels.live`, it now:
- Spaces the paragraphs correctly in the synopsis,
- Has more metadata: synopsis and tags,
- Eliminates the `\'` artifact commonly seen in the earlier scrapper,
- Has speed optimizations for chapter downloads.

The finished scrapper was tested on my local machine.