### PR TITLE
Added Sleep time because timeout error

### DIFF
--- a/lncrawl/templates/novelmtl.py
+++ b/lncrawl/templates/novelmtl.py
@@ -93,4 +93,7 @@ class NovelMTLTemplate(SearchableSoupTemplate, ChapterOnlySoupTemplate):
         )
 
     def select_chapter_body(self, soup: BeautifulSoup) -> Tag:
-        return soup.select_one(".chapter-content")
+        time.sleep(15)
+        text = soup.select_one(".chapter-content")
+        time.sleep(15)
+        return text


### PR DESCRIPTION
All this temple websites are countering the crawlers when you visit alot urls at the same time and error ``Timeout error``, to counter that have added sleep timeout of total of 30 seconds.
Suggestions

-maybe someone can make this better by looking how websites are check the url like cache ,IP etc