### PR TITLE
Fixed Freewebnovel

### DIFF
--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -21,7 +21,7 @@ class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
             {
                 "p": [
                     r"freewebnovel\.com",
-                    r"innread\.com"
+                    r"innread\.com",
                     r"Updates by Freewebnovel\. com",
                     r"” Search Freewebnovel\.com\. on google”\.",
                     r"\/ Please Keep reading on MYFreeWebNovel\.C0M",

--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -22,6 +22,7 @@ class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
                 "p": [
                     r"freewebnovel\.com",
                     r"innread\.com",
+                    r"bednovel\.com",
                     r"Updates by Freewebnovel\. com",
                     r"” Search Freewebnovel\.com\. on google”\.",
                     r"\/ Please Keep reading on MYFreeWebNovel\.C0M",

--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -21,6 +21,7 @@ class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
             {
                 "p": [
                     r"freewebnovel\.com",
+                    r"innread\.com"
                     r"Updates by Freewebnovel\. com",
                     r"” Search Freewebnovel\.com\. on google”\.",
                     r"\/ Please Keep reading on MYFreeWebNovel\.C0M",

--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -14,7 +14,7 @@ class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
     base_url = ["https://freewebnovel.com/"]
 
     def initialize(self) -> None:
-        self.init_executor(1)
+        self.init_executor(ratelimit=2)
         self.cleaner.bad_tags.update(["h4", "sub"])
         self.cleaner.bad_tag_text_pairs.update(
             {

--- a/sources/en/f/freewebnovel.py
+++ b/sources/en/f/freewebnovel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import unicodedata
 
 from concurrent.futures import Future
 from typing import List
@@ -11,7 +12,7 @@ from lncrawl.templates.soup.searchable import SearchableSoupTemplate
 
 
 class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
-    base_url = ["https://freewebnovel.com/"]
+    base_url = ["https://freewebnovel.com/", "https://bednovel.com/", "https://innread.com/"]
 
     def initialize(self) -> None:
         self.init_executor(ratelimit=2)
@@ -98,5 +99,13 @@ class FreeWebNovelCrawler(SearchableSoupTemplate, ChapterOnlySoupTemplate):
             title=tag.text.strip(),
         )
 
+    def normalize_text(self, text: str) -> str:
+        return unicodedata.normalize("NFKC", text)
+
     def select_chapter_body(self, soup: BeautifulSoup) -> Tag:
-        return soup.select_one(".m-read .txt")
+        body_tag = soup.select_one(".m-read .txt")
+        if body_tag:
+            normalized_body = self.normalize_text(str(body_tag))
+            normalized_soup = BeautifulSoup(normalized_body, "html.parser")
+            return normalized_soup
+        return body_tag


### PR DESCRIPTION
So I've added two new domain names, as freewebnovel and bednovel are alternative domains for their main site, innread.com.

I've added `self.init_executor(ratelimit=2)` because otherwise I get `HTTPError: 429 Client Error: Too Many Requests`. I've tried a higher number than 2, but the error comes back.

The last change is that I noticed with freewebnovel (and other domains) that it would have random text in chapters like "innread.com", but it would be weird unicode text, which means it can't be searched and removed normally. So I used unicodedata and normalized the chapter text, which removed the weird watermarks, but then it removed formatting, so I had to update again to fix that.

I've tested it on a few novels, and it works fine. It's a bit slow scraping because of the rate limit, but it works, and all chapters are formatted properly without any watermarks.

Sorry, the `unicodedata.normalize` code isn't pretty, and if someone can rewrite it, go ahead, but I'm just not good enough.

**Update:** forgot to add " innread.com" to self.cleaner.bad_tag_text_pairs.update once it normalized done that now lol. Also "bednovel.com" just in case.