### PR TITLE
Add libxcb-cursor0 to Dockerfile

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,7 @@ USER root
 # Install general dependencies
 RUN apt-get update -yq \
     && apt-get install -yq \
-    wget tar xz-utils make cmake g++ libffi-dev libegl1 libopengl0 \
+    wget tar xz-utils make cmake g++ libffi-dev libegl1 libopengl0 libxcb-cursor0 \
     libnss3 libgl1-mesa-glx libxcomposite1 libxrandr2 libxi6 fontconfig \
     libxkbcommon-x11-0 libxtst6 libxkbfile1 libxcomposite-dev libxdamage-dev \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Calibre now needs the libxcb-cursor0 library before installing. (kovidgoyal/calibre@2d92d10)