### PR TITLE
update lightnovelreader.py URL for readlightnovel.app to readlitenove…

### DIFF
--- a/sources/en/l/lightnovelreader.py
+++ b/sources/en/l/lightnovelreader.py
@@ -19,7 +19,7 @@ class LightnovelReader(Crawler):
         "https://lnreader.org/",
         "https://www.lnreader.org/",
         "http://readlightnovel.online/",
-        "https://readlightnovel.app/",
+        "https://readlitenovel.com/",
     ]
 
     def initialize(self) -> None:


### PR DESCRIPTION
Closes #2236 

This command now works:

`python -m lncrawl -s https://readlitenovel.com/the-beginning-after-the-end-535558` and uses the same source which previously handled that site.