### PR TITLE
Change in Termux installation manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $ docker run -v ~/Lightnovels:/home/appuser/app/Lightnovels -it lncrawl
 - Install [Termux](https://play.google.com/store/apps/details?id=com.termux) from playstore.
 - Open the app and run these commands one by one:
   - `pkg upgrade`
-  - `pkg install python libxml2 libxslt libjpeg-turbo webp rust`
+  - `pkg install python libxml2 libxslt libjpeg-turbo rust python-lxml python-grpcio`
   - `pip install -U pip wheel setuptools`
   - `pip install lightnovel-crawler`
   - `termux-setup-storage`


### PR DESCRIPTION
- there is no webp package
- added python-lxml and python-grpcio

Termux do not have webp package and I am not sure if it even is needed. 
Installing lxml and grpcio fails on compilation. There are workarounds, but time consuming and unreliable. Fortunatelly thermux have them now as packages.