### PR TITLE
add Uukanshu (www & tw subdomains)

### DIFF
--- a/sources/zh/uukanshu.py
+++ b/sources/zh/uukanshu.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from bs4 import Tag
+
+from lncrawl.core.crawler import Crawler
+from lncrawl.models import Chapter, Volume
+from sources.zh.uukanshu_sj import UukanshuOnlineSJ
+
+logger = logging.getLogger(__name__)
+
+novel_search_url = "%ssearch.aspx?k=%s"
+
+
+class UukanshuOnline(Crawler):
+    # www is simplified cn, tw is traditional cn but both use same site structure
+    base_url = ["https://www.uukanshu.net/", "https://tw.uukanshu.net/"]
+
+    encoding = "gbk"
+
+    def initialize(self):
+        # the default lxml parser cannot handle the huge gbk encoded sites (fails after 4.3k chapters)
+        self.init_parser("html.parser")
+
+    def read_novel_info(self) -> None:
+        # the encoding for tw is utf-8, for www. is gbk -> otherwise output is messed up with wrong symbols.
+        if "tw." in self.novel_url:
+            self.encoding = "utf-8"
+
+        soup = self.get_soup(self.novel_url, encoding=self.encoding)
+        info = soup.select_one("dl.jieshao")
+        assert info  # if this fails, HTML structure has fundamentally changed -> needs update
+        meta = info.select_one("dd.jieshao_content")
+
+        img = info.select_one("dt.jieshao-img img")
+        if img:
+            self.novel_cover = self.absolute_url(img["src"])
+
+        self.novel_title = meta.select_one("h1 > a").text
+        self.novel_author = meta.select_one("h2 > a").text
+        self.novel_synopsis = meta.select_one("h3 > p").text
+
+        chapters = soup.select_one("ul#chapterList")
+        for chapter in list(chapters.children)[::-1]:  # reverse order as it's newest to oldest
+            # convince typehint that we're looking at Tags & also make sure we skip random text within the ul if any
+            if not isinstance(chapter, Tag):
+                continue
+            # find chapters
+            if chapter.has_attr("class") and "volume" in chapter["class"]:
+                self.volumes.append(
+                    Volume(
+                        id=len(self.volumes) + 1,
+                        title=chapter.text.strip(),
+                    )
+                )
+                continue
+            anchor = chapter.select_one("a")
+            if not anchor:
+                logger.warning("Found <li> in chapter list, not volume, without link: %s", chapter)
+                continue
+            self.chapters.append(
+                Chapter(
+                    id=len(self.chapters) + 1,
+                    url=self.absolute_url(anchor["href"]),
+                    title=anchor.text,
+                    volume=len(self.volumes),
+                )
+            )
+
+    def download_chapter_body(self, chapter: Chapter) -> str:
+        soup = self.get_soup(chapter.url, encoding=self.encoding)
+        content = soup.select_one("div#contentbox")
+        # use same filters as already implemented on essentially same site
+        return UukanshuOnlineSJ.format_text(self.cleaner.extract_contents(content))

--- a/sources/zh/uukanshu_sj.py
+++ b/sources/zh/uukanshu_sj.py
@@ -11,7 +11,7 @@ novel_search_url = "%ssearch.aspx?k=%s"
 chapter_list_url = "%s&page=%d"
 
 
-class UukanshuOnline(Crawler):
+class UukanshuOnlineSJ(Crawler):
     base_url = ["https://sj.uukanshu.net/"]  # previously .com, redirects .com to .net though
 
     def search_novel(self, query):
@@ -88,7 +88,8 @@ class UukanshuOnline(Crawler):
 
         return self.format_text(content)
 
-    def format_text(self, text):
+    @staticmethod
+    def format_text(text):
         text = re.sub(
             r"[UＵ][UＵ]\s*看书\s*[wｗ][wｗ][wｗ][\.．][uｕ][uｕ][kｋ][aａ][nｎ][sｓ][hｈ][uｕ][\.．][cｃ][oｏ][mｍ]",
             "",

--- a/sources/zh/uukanshu_sj.py
+++ b/sources/zh/uukanshu_sj.py
@@ -12,7 +12,7 @@ chapter_list_url = "%s&page=%d"
 
 
 class UukanshuOnline(Crawler):
-    base_url = ["https://sj.uukanshu.com/"]
+    base_url = ["https://sj.uukanshu.net/"]  # previously .com, redirects .com to .net though
 
     def search_novel(self, query):
         query = query.lower().replace(" ", "+")


### PR DESCRIPTION
Closes #2263 

There was already an existing Parser but that was for a very different looking `sj.` subdomain so I renamed the file & class whilst making use of its existing custom text filter.

I split up the commits in hope that it wouldn't destroy the existing git history on the previous sj subdomain crawler but that seems to not have worked when looking at the changelist of this PR... -> reviewing this PR in the **per commit view** would make the most sense.


The www subdomain returns simplified CN in GBK encoding, the tw subdomain returns traditional CN in utf-8 encoding.
I tried to explain in the code comments wherever it might be confusing.


Tested with a pretty large novel `https://www.uukanshu.net/b/86005/#gsc.tab=0` which has over 6k chapters and is split into 9 novels. Tested both tw and www subdomains, output matches website content.