### PR TITLE
cleaner: keep HTML table structure more intact

### DIFF
--- a/lncrawl/core/cleaner.py
+++ b/lncrawl/core/cleaner.py
@@ -138,6 +138,13 @@ class TextCleaner:
                 # the attributes to keep while cleaning a tag
                 "src",
                 "style",
+                # table and table children attributes
+                "colspan",
+                "rowspan",
+                "headers",
+                "scope",
+                "axis",
+                "id",  # id required for headers ref
             ]
         )
         self.whitelist_css_property: Set[str] = set(


### PR DESCRIPTION
Closes #2285 

Tested manually with the link provided in the aforementioned issue, seems to work as intended. 

An alternative to whitelisting the attributes would be to whitelist the entire table elements via unchanged_tags but I'm not sure if that's wanted.
