### PR TITLE
Sort search results by amount then by similarity with input

### DIFF
--- a/lncrawl/core/novel_search.py
+++ b/lncrawl/core/novel_search.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 
 from concurrent.futures import Future
 from slugify import slugify
+import difflib
 
 from ..models import CombinedSearchResult, SearchResult
 from .sources import crawler_list, prepare_crawler
@@ -101,5 +102,10 @@ def search_novels(app):
                 novels=value,
             )
         )
-    processed.sort(key=lambda x: -len(x.novels))
+    processed.sort(
+        key=lambda x: (
+            -len(x.novels),
+            -difflib.SequenceMatcher(None, x.title, app.user_input).ratio(),
+        )
+    )
     app.search_results = processed[:MAX_RESULTS]


### PR DESCRIPTION
for the input `Lord Of Mysteries 2: Circle Of Inevitability`
![image](https://github.com/dipu-bd/lightnovel-crawler/assets/86294972/d4dced10-e187-4a0b-a8ed-7d350c5af1b7)
We can see `Lord Of Mysteries 2: Circle of` is higher than the other 2 sources results because its title is close to the input string, whereas before it would have been out of the 15 results limit.

It's mostly useful for lesser known novels where results can be drawn below unrelated response (things like https://www.webfic.com/ returning 600 random novels)