### PR TITLE
Inverse invalid check

### DIFF
--- a/sources/zh/ixdzs.py
+++ b/sources/zh/ixdzs.py
@@ -19,7 +19,7 @@ class IxdzsCrawler(Crawler):
         """
         This manually 'fixes' URLs and prepares them for usage later on in string templating.
         """
-        url = url[:-1] if not url.endswith("/") else url
+        url = url[:-1] if url.endswith("/") else url
         if "https://tw.m.ixdzs.com" in url:
             return url.replace("https://tw.m.ixdzs.com", "https://ixdzs8.tw")
         if "https://www.aixdzs.com" in url:


### PR DESCRIPTION
The check should remove the trailing slash only if it has one, not only if it *doesn't* have one. Currently this has the effect of downloading a potentially different book (usually) if you *don't* put a slash and failing to download the chapters if you *do* put a slash.