### PR TITLE
Fix webnovel.com source

### DIFF
--- a/sources/en/w/webnovel.py
+++ b/sources/en/w/webnovel.py
@@ -32,7 +32,7 @@ class WebnovelCrawler(BasicBrowserTemplate):
 
     def get_csrf(self):
         logger.info("Getting CSRF Token")
-        self.get_response(self.home_url)
+        self.get_response(f"{self.home_url}stories/novel")
         self.csrf = self.cookies["_csrfToken"]
         logger.debug("CSRF Token = %s", self.csrf)
 
@@ -94,8 +94,8 @@ class WebnovelCrawler(BasicBrowserTemplate):
         self.novel_title = book_info["bookName"]
 
         self.novel_cover = (
-            f"{self.origin.scheme}://img.webnovel.com/bookcover/{self.novel_id}/600/600.jpg"
-            + f"?coverUpdateTime{int(1000 * time())}&imageMogr2/quality/40"
+            f"{self.origin.scheme}://book-pic.webnovel.com/bookcover/{self.novel_id}"
+            + f"?coverUpdateTime{int(1000 * time())}&imageMogr2/thumbnail/600x"
         )
 
         if "authorName" in book_info:


### PR DESCRIPTION
The issue with chapter downloads was that webnovel stopped setting the `_csfrToken` cookie on requests to index page. My workaround is to request `www.webnovel.com/stories/novel` instead, where they still do set it. This could've been any page, I chose `stories/novel` at random.

![image](https://github.com/user-attachments/assets/18cfbceb-18d8-40fe-9084-e746a2efe7f8)

Next, the issue with cover downloads was that they changed their URLs from `img.webnovel.com` to `book-pic.webnovel.com`. They also changed the URL parameters and format slightly. My (hacky) fix works - the cover downloaded for me - but I'm not sure whether it will work for all cases. In particular I didn't bother to find the `imageId` parameter after I saw that it works without it, and I kept the `coverUpdateTime` parameter even though it's probably not used anymore.

![image](https://github.com/user-attachments/assets/4bda8d76-397e-4374-bfea-ff77cc937fa0)

This PR should address:
#2562 
#2514
#2459
#2402
