### PR TITLE
Fix fanmtl.com / resolve_future add exceptions

### DIFF
--- a/lncrawl/core/taskman.py
+++ b/lncrawl/core/taskman.py
@@ -171,8 +171,8 @@ class TaskManager(ABC):
         futures: Iterable[Future],
         timeout: Optional[float] = None,
         disable_bar=False,
-        desc=None,
-        unit=None,
+        desc='',
+        unit='item',
         fail_fast=False,
     ) -> List[Any]:
         """Wait for the futures to be done.
@@ -188,11 +188,6 @@ class TaskManager(ABC):
         """
         if not futures:
             return []
-        
-        if desc is None:
-            raise Exception("resolve_future's \"desc\" parameter is None.")
-        if unit is None:
-            raise Exception("resolve_future's \"unit\" parameter is None.")
 
         _futures = list(futures or [])
         bar = self.progress_bar(

--- a/lncrawl/core/taskman.py
+++ b/lncrawl/core/taskman.py
@@ -188,6 +188,11 @@ class TaskManager(ABC):
         """
         if not futures:
             return []
+        
+        if desc is None:
+            raise Exception("resolve_future's \"desc\" parameter is None.")
+        if unit is None:
+            raise Exception("resolve_future's \"unit\" parameter is None.")
 
         _futures = list(futures or [])
         bar = self.progress_bar(

--- a/sources/en/f/fanmtl.py
+++ b/sources/en/f/fanmtl.py
@@ -48,7 +48,7 @@ class FanMTLCrawler(ChapterOnlyBrowserTemplate):
         for page in range(page_count):
             page_url = f"{common_page_url}?page={page}&wjm={params['wjm'][0]}"
             futures.append(self.executor.submit(self.get_soup, page_url))
-        for soup in self.resolve_futures(futures, desc="Pages"):
+        for soup in self.resolve_futures(futures, desc="TOC", unit="page"):
             yield from soup.select("ul.chapter-list li a")
 
     def parse_chapter_item(self, tag: Tag, id: int) -> Chapter:


### PR DESCRIPTION
resolve_futures has bad default values (None) for desc and unit. If not defined by the caller, it will error downstream the callstack. This pull request fixes only the fanmtl source, and does not touch that default behaviour. I will address this in another pull request.
fixes #2577, fixes #2581, fixes #2599