### PR TITLE
fix(novelfull): remove embedded ads from chapter content

### DIFF
--- a/lncrawl/templates/novelfull.py
+++ b/lncrawl/templates/novelfull.py
@@ -71,4 +71,8 @@ class NovelFullTemplate(SearchableSoupTemplate, ChapterOnlySoupTemplate):
         )
 
     def select_chapter_body(self, soup: BeautifulSoup) -> Tag:
-        return soup.select_one("#chr-content, #chapter-content")
+        contents = soup.select_one("#chr-content, #chapter-content")
+        for ads in contents.select("div"):
+            ads.extract()
+
+        return contents


### PR DESCRIPTION
This removes ads and irrelevant notices commonly found in sources using this template (e.g., novelfull, novelbin, novel-bin, etc.), cleaning the final output.