### PR TITLE
added source arcane translation

### DIFF
--- a/sources/id/arcanetranslations.py
+++ b/sources/id/arcanetranslations.py
@@ -1,0 +1,19 @@
+import logging
+
+from lncrawl.templates.mangastream import MangaStreamTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class Arcanetranslations(MangaStreamTemplate):
+    has_mtl = False
+    has_manga = False
+    base_url = ["https://arcanetranslations.com/"]
+
+    def select_chapter_body(self, tag):
+        result = super().select_chapter_body(tag)
+        if "Login to buy access to this content" in result.text:
+            raise Exception(
+                "This content is behind a paywall. Please login to access it."
+            )
+        return result


### PR DESCRIPTION
#2598
Not sure how to deal with locked chapter, maybe I should have ignored it, then we can just delete the select_chapter_body override I added.
I raised an error so that it doesn't create the chapter file and set it as success:true in meta.json. So if we run the app again, it will fill in the missing chapters instead of leaving it as "Login to buy access to this content" despite the chapter being available since.