### PR TITLE
fix: allow downloads of all free chapters

### DIFF
--- a/sources/en/n/novelight.py
+++ b/sources/en/n/novelight.py
@@ -86,7 +86,7 @@ class NoveLightCrawler(Crawler):
         encountered_paid_chapter = False
         for page in reversed(chapters_lists):
             if encountered_paid_chapter:
-                break
+                continue
             params = {
                 "csrfmiddlewaretoken": csrfmiddlewaretoken,
                 "book_id": book_id,
@@ -100,7 +100,6 @@ class NoveLightCrawler(Crawler):
             for a in reversed(chapters_soup.select("a[href^='/book/chapter/']")):
                 if a.select_one(".chapter-info .cost"):
                     encountered_paid_chapter = True
-                    break
                 else:
                     self.chapters.append(
                         Chapter(


### PR DESCRIPTION
I've encountered a scenario where a chapter page has a single paid chapter in the middle, thus causing lightnovel-crawler to stop crawling the rest of the chapters on that page as well as all other pages.