### PR TITLE
Fix: Make VIP check optional for Discord bot access

### DIFF
--- a/lncrawl/bots/discord/discord_bot.py
+++ b/lncrawl/bots/discord/discord_bot.py
@@ -96,7 +96,7 @@ class DiscordBot(discord.Client):
                 self.handlers[uid].process(message)
             elif (
                 len(self.handlers) > C.max_active_handles
-                or discriminator not in C.vip_users_ids
+                and discriminator not in C.vip_users_ids
             ):
                 async with message.author.typing():
                     await message.author.send(


### PR DESCRIPTION
This PR fixes the issue described in #2552 where non-VIP users are unable to use the Discord bot even when there were no active handlers, receiving a "too busy" message regardless of the bot's actual load.