### PR TITLE
Fix shared mutable defaults in Args class

### DIFF
--- a/lncrawl/core/arguments.py
+++ b/lncrawl/core/arguments.py
@@ -9,11 +9,11 @@ from .display import LINE_SIZE
 
 
 class Args:
-    def __init__(self, *args, mutex: list = [], group: list = [], **kargs):
+    def __init__(self, *args, mutex=None, group=None, **kargs):
         self.args = args
         self.kargs = kargs
-        self.group = group
-        self.mutex = mutex
+        self.group = group or []
+        self.mutex = mutex or []
         self.arguments = None
 
     def build(self, parser=None):


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults in `Args` constructor

## Testing
- `pytest`
- `python - <<'PY'
from lncrawl.core.arguments import Args

a = Args()
b = Args()

a.group.append('x')
a.mutex.append('y')

print('a.group', a.group)
print('b.group', b.group)
print('group shared?', a.group is b.group)
print('a.mutex', a.mutex)
print('b.mutex', b.mutex)
print('mutex shared?', a.mutex is b.mutex)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68974ef2e7bc832e8a901a173b962e5a