### PR TITLE
feat: add series metadata following EPUB 3.3 standard

### DIFF
--- a/lncrawl/binders/epub.py
+++ b/lncrawl/binders/epub.py
@@ -23,6 +23,7 @@ def bind_epub_book(
     chapter_groups: List[List[Chapter]],  # chapters grouped by volumes
     images: List[str],  # full path of images to add
     suffix: str,  # suffix to the file name
+    novel_idx: int,  # position in the series
     book_title: str,
     is_rtl: bool = False,
 ):
@@ -49,6 +50,12 @@ def bind_epub_book(
     book.add_author(novel_author)
     book.add_metadata('DC', 'description', novel_synopsis)
     book.set_identifier(output_path + suffix)
+
+    # add series metadata
+    book.add_metadata(None, 'meta', 'series', {'property': 'collection-type'})
+    book.add_metadata(None, 'meta', novel_title, {'property': 'belongs-to-collection'})
+    book.add_metadata(None, 'meta', str(novel_idx), {'property': 'group-position'})
+
     if is_rtl:
         book.set_direction("rtl")
 
@@ -206,6 +213,7 @@ def make_epubs(app, data: Dict[str, List[Chapter]]) -> Generator[str, None, None
     from ..core.app import App
     assert isinstance(app, App) and app.crawler
 
+    novel_idx = 1
     for volume, chapters in data.items():
         if not chapters:
             continue
@@ -230,5 +238,8 @@ def make_epubs(app, data: Dict[str, List[Chapter]]) -> Generator[str, None, None
             chapter_groups=list(volumes.values()),
             images=list(images),
             suffix=volume,
+            novel_idx=novel_idx,
             book_title=book_title,
         )
+
+        novel_idx += 1


### PR DESCRIPTION
This PR adds the custom opf metadata tags included in the EPUB 3.X spec, which allow for many epub readers and management tools (Such as kavita for example), to aggregate epubs into a single series when using the `--multi` flag to split the download into multiple volumes. 

References: 
- https://www.w3.org/TR/epub-33/#sec-belongs-to-collection
- https://www.w3.org/TR/epub-33/#sec-collection-type
- https://www.w3.org/TR/epub-33/#sec-group-position