### PR TITLE
Add rate limit for downloads

### DIFF
--- a/lncrawl/core/arguments.py
+++ b/lncrawl/core/arguments.py
@@ -303,6 +303,14 @@ _builder = Args(
             help="Do not prompt to close at the end for windows platforms.",
         ),
         Args(
+            "--ratelimit",
+            dest="ratelimit",
+            metavar="LIMIT",
+            type=float,
+            default=60.0,
+            help="Limit downloads to x chapters per minute.",
+        ),
+        Args(
             "--resume",
             dest="resume",
             nargs="?",

--- a/lncrawl/core/crawler.py
+++ b/lncrawl/core/crawler.py
@@ -164,9 +164,13 @@ class Crawler(Scraper):
     ) -> Generator[Chapter, None, None]:
         def _downloader(chapter: Chapter):
             # implement rate limiting
-            current_time = time.monotonic()
-            if current_time < self.next_download_timepoint:
-                time.sleep(self.next_download_timepoint - current_time)
+            while self.next_download_timepoint - time.monotonic() > 0.5:
+                # fast breakout on CTRL+C
+                if signal.is_set():
+                    break
+                time.sleep(0.5)
+            if not signal.is_set() and time.monotonic() < self.next_download_timepoint:
+                time.sleep(self.next_download_timepoint - time.monotonic())
             self.next_download_timepoint = time.monotonic() + self.time_between_downloads
 
             chapter.body = ""

--- a/lncrawl/core/crawler.py
+++ b/lncrawl/core/crawler.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import time
 from abc import abstractmethod
 from threading import Event
 from typing import Generator, List, Optional, Union
@@ -53,6 +54,14 @@ class Crawler(Scraper):
         self.is_rtl: bool = False
         self.novel_synopsis: str = ""
         self.novel_tags: List[str] = []
+
+        # timepoint at which the next download can start
+        self.next_download_timepoint = 0.0  # can start immediatly
+        if get_args().ratelimit and get_args().ratelimit > 0:
+            # ratlimit is items/minute -> invert to get duration in seconds between downloads
+            self.time_between_downloads = 60.0 / get_args().ratelimit
+        else:
+            self.time_between_downloads = 0
 
         # Each item must contain these keys:
         # `id` - 1 based index of the volume
@@ -154,6 +163,12 @@ class Crawler(Scraper):
         signal=Event(),
     ) -> Generator[Chapter, None, None]:
         def _downloader(chapter: Chapter):
+            # implement rate limiting
+            current_time = time.monotonic()
+            if current_time < self.next_download_timepoint:
+                time.sleep(self.next_download_timepoint - current_time)
+            self.next_download_timepoint = time.monotonic() + self.time_between_downloads
+
             chapter.body = ""
             chapter.images = {}
             chapter.body = self.download_chapter_body(chapter)


### PR DESCRIPTION
Some websites limit the number of accesses to it and it should also be in the interesst of all to be good netizens and not overly stress pages.

Allow the user to restict the access to pages to x per minute, whereas values smaller then 1 result in less then one access per minute. 0.5 will result in one access every two minutes, reducing strain on the webservers we get our novels from.

Default has been set to 1 per second, which is quite high, but in the spirit of the previous implementation which did not throttle at all.